### PR TITLE
Install script

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^inst/Gruntfile.js$
 ^inst/node_modules$
 ^inst/package.json$
+^install.sh$

--- a/cleanup
+++ b/cleanup
@@ -1,7 +1,11 @@
 #! /usr/bin/env bash
 
-cd inst
-npm install
-bower install
-grunt
-( cd bower_components/jquery.sparkline && make )
+(
+    cd inst
+    if [ -z $RCAP_BUILD_FAST ]; then
+	npm install
+	bower install
+	( cd bower_components/jquery.sparkline && make )
+    fi
+    grunt
+)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+echo "WARNING: Not running 'npm install', you might need to run it manually"
+echo "WARNING: Not running 'bower install', you might need to run it manually"
+
+(
+    pkgdir=$(basename `pwd`)
+    pkgname=$(sed -n 's/^Package: //p' DESCRIPTION)
+    pkgversion=$(sed -n 's/^Version: //p' DESCRIPTION)
+
+    cd ..
+
+    export RCAP_BUILD_FAST=hellyes
+    R CMD build $pkgdir
+
+    R CMD INSTALL ${pkgname}_${pkgversion}.tar.gz
+)


### PR DESCRIPTION
For the new organization. Instead of the `grunt` call, you'll need to run `./install.sh`. 

To update the bower and npm packages (if you change them, or first time) you need:
```sh
( cd inst && 
  npm install && 
  bower install && 
  cd bower_components/jquery.sparkline && make )
```

@shaneporter @NattyE Please try and let me know if it works for you.