### PR TITLE
fix the build script so it works unattended and uses consistent build tools

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,11 +1,36 @@
 #! /usr/bin/env bash
 
 (
+    BROOT="`pwd`"
     cd inst
-    if [ -z $RCAP_BUILD_FAST ]; then
-	npm install
-	bower install --allow-root
-	( cd bower_components/jquery.sparkline && make )
-	grunt
+    if [ -z "$RCAP_BUILD_FAST" ]; then
+	echo Building dependencies ...
+	if npm version | grep npm: >/dev/null; then
+	    echo npm ... OK
+	else
+	    echo 'ERROR: cannot find npm - try "sudo apt-get install npm" first'
+	    exit 1
+	fi
+	if sass -v | grep ^Sass > /dev/null; then
+	    echo Ruby sass ... OK
+	else
+	    echo 'ERROR: cannot find sass - try "sudo apt-get install ruby-sass" first'
+	    exit 1
+	fi
+
+	npm install || exit 1
+
+	## some of the NJS/bower modules are brain-dead and make assumptions about
+	## things being installed system-wide, so we have to use local paths and
+	## add uglifyjs module to the PATH (eek)
+	PATH="$BROOT/inst/node_modules/uglifyjs/bin:$PATH"
+	export PATH
+	node_modules/bower/bin/bower install --allow-root || exit 1
+	( cd bower_components/jquery.sparkline && make ) || exit 1
+	node_modules/grunt-cli/bin/grunt || exit 1
+
+	## FIXME: we should delete the dev pieces from the distribution!
+	## someone familiar with what's actually used please adjust the following
+	rm -rf node_modules bower_components
     fi
 )

--- a/inst/package.json
+++ b/inst/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "~1.1.0",
+    "bower": "~1.7.9",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-jshint": "^0.11.2",


### PR DESCRIPTION
This PR allows `rcloud.rcap` to be built automatically from the GH repo. It only requires `npm` and `sass` - both are checked for by the build script to give reasonable error messages. All other pieces are installed locally without any system requirements.