### PR TITLE
Datatable: can now contain '.' in column names

### DIFF
--- a/inst/www/js/ui/controls/dataTable.js
+++ b/inst/www/js/ui/controls/dataTable.js
@@ -163,8 +163,6 @@ define(['rcap/js/ui/controls/gridControl',
 
             result = JSON.parse(result);
 
-            console.log(result);
-
             if($.fn.DataTable.isDataTable('#' + controlId)) {
                 var dt = $('#' + controlId).dataTable().api();
                 dt.destroy();

--- a/inst/www/js/ui/controls/dataTable.js
+++ b/inst/www/js/ui/controls/dataTable.js
@@ -163,6 +163,8 @@ define(['rcap/js/ui/controls/gridControl',
 
             result = JSON.parse(result);
 
+            console.log(result);
+
             if($.fn.DataTable.isDataTable('#' + controlId)) {
                 var dt = $('#' + controlId).dataTable().api();
                 dt.destroy();
@@ -174,7 +176,12 @@ define(['rcap/js/ui/controls/gridControl',
             var dtProperties = {
                 dom: 'Blfrtip', 
                 data:  result.data,
-                columns: result.columns.map(function(x){ return {data: x, title: x }; })
+                columns: result.columns.map(function(col) { 
+                    return { 
+                        data: col.replace(/\./g,'\\.'), // escape '.' for datatables 
+                        title: col 
+                    }; 
+                })
             };
 
             // pass in dynamic options from R


### PR DESCRIPTION
This fixes issue #145. Column names escaped in accordance to datatables rules for '.' column names.

Also gave the the code some more room to breathe. BecauseIliketousewhitespace.