### PR TITLE
Modifying page details doesn't thrown an error

### DIFF
--- a/inst/www/js/ui/gridManager.js
+++ b/inst/www/js/ui/gridManager.js
@@ -298,11 +298,9 @@ define([
 
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////
-            PubSub.subscribe(pubSubTable.updatePage, function(msg, pageData) {
-
-                $('.grid-stack[data-pageid="' + pageData.id + '"]').css('background-color', _.findWhere(pageData.styleProperties, { uid : 'backgroundColor' }).value);
-
-            });
+            // PubSub.subscribe(pubSubTable.updatePage, function(msg, pageData) {
+            //     $('.grid-stack[data-pageid="' + pageData.id + '"]').css('background-color', _.findWhere(pageData.styleProperties, { uid : 'backgroundColor' }).value);
+            // });
             
             /////////////////////////////////////////////////////////////////////////////////////////////////////////
             PubSub.subscribe(pubSubTable.pageAdded, function(msg, pageData) {


### PR DESCRIPTION
Looks as though I'd accidentally pushed something regarding individual page styling.

The grid manager's subscription to 'updatePage', published when the page details are changed, was expecting to find a `styleProperties` property.