### PR TITLE
Page menu set's dirty flag accordingly

### DIFF
--- a/inst/www/js/ui/controls/pageMenu.js
+++ b/inst/www/js/ui/controls/pageMenu.js
@@ -14,6 +14,7 @@ define(['rcap/js/ui/controls/gridControl',
         // directly, let its caller handle the returned markup, otherwise fire the 
         // event:
         if (publishEvent) {
+            control.isDirty = false;
             PubSub.publish(pubSubTable.updateControl, control);
         } else {
 

--- a/inst/www/js/ui/dialogManager.js
+++ b/inst/www/js/ui/dialogManager.js
@@ -43,6 +43,7 @@ define([
             });
 
             // push the updated event:
+            originatingControl.isDirty = true;
             PubSub.publish(pubSubTable.updateControl, originatingControl);
 
             $('#dialog-controlSettings').jqmHide();

--- a/inst/www/js/ui/dirtyStateIndicator.js
+++ b/inst/www/js/ui/dirtyStateIndicator.js
@@ -46,7 +46,7 @@ define(['pubsub', 'site/pubSubTable', 'rcap/js/utils/rcapLogger'], function(PubS
                 modifyingEvents.forEach(function(e) {
                     PubSub.subscribe(e, function(msg, msgInfo) {
                         // if dirty has been set AND is true:
-                        if((!_.isUndefined(msgInfo.isDirty) && msgInfo.isDirty) || _.isUndefined(msgInfo.isDirty)) {
+                        if(!_.isUndefined(msgInfo.isDirty) && msgInfo.isDirty) {
                             rcapLogger.info('dirtyStateIndicator, setting modified after receiving: pubSubTable.' + msg);
                             isDirty = true;
                             el.show();  

--- a/inst/www/js/ui/dirtyStateIndicator.js
+++ b/inst/www/js/ui/dirtyStateIndicator.js
@@ -45,7 +45,8 @@ define(['pubsub', 'site/pubSubTable', 'rcap/js/utils/rcapLogger'], function(PubS
 
                 modifyingEvents.forEach(function(e) {
                     PubSub.subscribe(e, function(msg, msgInfo) {
-                        if(_.isUndefined(msgInfo.isDirty) || (!_.isUndefined(msgInfo.isDirty) && !msgInfo.isDirty)) {
+                        // if dirty has been set AND is true:
+                        if((!_.isUndefined(msgInfo.isDirty) && msgInfo.isDirty) || _.isUndefined(msgInfo.isDirty)) {
                             rcapLogger.info('dirtyStateIndicator, setting modified after receiving: pubSubTable.' + msg);
                             isDirty = true;
                             el.show();  


### PR DESCRIPTION
This fixes #165, where the page menu was prematurely setting the dirty state indicator's modified state.

I also noticed that changing the page menu's style (mobile, vertical, horizontal etc.) would not update the modified state properly. That's been fixed with c6779cf.