### PR TITLE
Fixes #181 asset/theme CSS issue

### DIFF
--- a/inst/www/js/assetManager.js
+++ b/inst/www/js/assetManager.js
@@ -6,7 +6,7 @@ define(['pubsub',
     var AssetManager = function() {
 
         var assetIdentifier = 'rcap_designer.json',
-            themeAssetIdentifier = 'rcap_designer.css',
+            cssAssetIdentifier = 'rcap_designer.css',
             shell = window.shell;
 
         var getNotebookAsset = function(filename) {
@@ -18,19 +18,23 @@ define(['pubsub',
             });
         };
 
+        var cacheBustUrl = function(url) {
+            return url + '?cachebuster=' + Math.random().toString(16).slice(2);
+        };
+
         this.initialise = function() {
 
             var me = this;
-            
+
             // subscribe to theme change:
             PubSub.subscribe(pubSubTable.updateTheme, function(msg, content) {
-                me.save(content, themeAssetIdentifier, 'css');
+                me.save(content, cssAssetIdentifier, 'css');
                 PubSub.publish(pubSubTable.updateDomTheme, me.getThemeUrl());
             });
 
             PubSub.subscribe(pubSubTable.editTheme, function() {
                 // get the asset, show the dialog:
-                var asset = getNotebookAsset(themeAssetIdentifier);
+                var asset = getNotebookAsset(cssAssetIdentifier);
 
                 PubSub.publish(pubSubTable.showThemeEditorDialog, asset ? asset.content() : '');
             });
@@ -50,7 +54,7 @@ define(['pubsub',
             }
 
             PubSub.publish(pubSubTable.saved, {
-                wasTheme: filename === themeAssetIdentifier
+                wasTheme: filename === cssAssetIdentifier
             });
         };
 
@@ -59,24 +63,23 @@ define(['pubsub',
             return existingAsset ? existingAsset.content() : '';
         };
 
-        this.getThemeUrl = function(designTime, themeExists) {
+        this.getThemeUrl = function(designTime, cssAssetExists) {
             if(designTime) {
-                var theme = getNotebookAsset(themeAssetIdentifier);
+                var theme = getNotebookAsset(cssAssetIdentifier);
                 if(theme) {
-                    return '/notebook.R/' + shell.gistname() + '/' + themeAssetIdentifier + '?cachebuster=' + Math.random().toString(16).slice(2);
+                    return cacheBustUrl('/notebook.R/' + shell.gistname() + '/' + cssAssetIdentifier);
                 } else {
                     return undefined;
-                }    
-            } else if(themeExists) {
+                }
+            } else if(cssAssetExists) {
                 var getNotebookId = function(name) {
                     return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null; // jshint ignore: line
                 };
 
-                return '/notebook.R/' + getNotebookId('notebook') + '/' + themeAssetIdentifier + '?cachebuster=' + Math.random().toString(16).slice(2);
+                return cacheBustUrl('/notebook.R/' + getNotebookId('notebook') + '/' + cssAssetIdentifier);
             } else {
                 return undefined;
             }
-            
         };
     };
 

--- a/inst/www/js/site/siteManager.js
+++ b/inst/www/js/site/siteManager.js
@@ -92,11 +92,9 @@ define([
                 });
 
                 var themeUrl = assetManager.getThemeUrl(site.isDesignTime, site.themeExists);
-
                 if(themeUrl) {
                     PubSub.publish(pubSubTable.updateDomTheme, themeUrl);
                 }
-
             });
 
             ////////////////////////////////////////////////////////////////////////////////////

--- a/inst/www/js/ui/themeManager.js
+++ b/inst/www/js/ui/themeManager.js
@@ -11,7 +11,7 @@ define(['pubsub',
 
             // subscribe to theme change:
             PubSub.subscribe(pubSubTable.updateDomTheme, function(msg, themeUri) {
-                me.applyTheme(themeUri);
+                me.applyAssetTheme(themeUri);
             });
 
             PubSub.subscribe(pubSubTable.updateSiteThemePackage, function(msg, siteThemePackage) {
@@ -31,31 +31,55 @@ define(['pubsub',
             $('head > link.rcap').remove();
         };
 
-        this.addLink = function(themeUri, stylesheetClass) {
+        this.applyLink = function(themeUri, stylesheetClass) {
 
+            // first remove the link, if any:
             $('head > link.' + stylesheetClass).remove();
 
-            if(themeUri) {
-                $('head')
-                    .append($('<link />')
+            // validate stylesheetClass:
+            if(['package', 'asset'].indexOf(stylesheetClass) < 0 || !themeUri){
+                return;
+            }
+
+            var linkToInsert = $('<link />')
                     .attr({
                         'class': stylesheetClass,
                         'type': 'text/css',
                         'rel': 'stylesheet',
                         'href': themeUri
-                    }));
+                    });
+
+            // valid order is package, asset:
+            var selectorPrefix = 'head > link.';
+
+            if(stylesheetClass === 'asset') {
+                var packageLink = $(selectorPrefix + 'package');
+
+                if(packageLink.length) {
+                    linkToInsert.insertAfter(packageLink);
+                } else {
+                    $('head').append(linkToInsert);
+                }
+            } else if(stylesheetClass === 'package') {
+                var assetLink = $(selectorPrefix + 'asset');
+
+                if(assetLink.length) {
+                    linkToInsert.insertBefore(assetLink);
+                } else {
+                    $('head').append(linkToInsert);
+                }
             }
         };
 
-        this.applyTheme = function(themeUri) {
-            this.addLink(themeUri, 'rcap');
+        this.applyAssetTheme = function(themeUri) {
+            this.applyLink(themeUri, 'asset');
         };
 
         this.applyPackageTheme = function(siteThemePackage) {
             if(siteThemePackage) {
-                this.addLink('/shared.R/' + siteThemePackage + '/rcap-style.css', 'rcappackage');
+                this.applyLink('/shared.R/' + siteThemePackage + '/rcap-style.css', 'package');
             } else {
-                this.addLink(undefined, 'rcappackage');
+                this.applyLink(undefined, 'package');
             }
         };
 

--- a/inst/www/js/ui/themeManager.js
+++ b/inst/www/js/ui/themeManager.js
@@ -8,7 +8,7 @@ define(['pubsub',
         this.initialise = function() {
 
             var me = this;
-            
+
             // subscribe to theme change:
             PubSub.subscribe(pubSubTable.updateDomTheme, function(msg, themeUri) {
                 me.applyTheme(themeUri);
@@ -28,20 +28,20 @@ define(['pubsub',
         };
 
         this.cleanUp = function() {
-            $('head > link.rcap').remove(); 
+            $('head > link.rcap').remove();
         };
 
         this.addLink = function(themeUri, stylesheetClass) {
 
-            $('head > link.' + stylesheetClass).remove(); 
+            $('head > link.' + stylesheetClass).remove();
 
             if(themeUri) {
                 $('head')
                     .append($('<link />')
-                    .attr({ 
-                        'class': 'rcap ' + stylesheetClass,
-                        'type': 'text/css', 
-                        'rel': 'stylesheet', 
+                    .attr({
+                        'class': stylesheetClass,
+                        'type': 'text/css',
+                        'rel': 'stylesheet',
                         'href': themeUri
                     }));
             }


### PR DESCRIPTION
This fixes issue #181, but also ensures that a predictable ordering of CSS assets are used.

That order is package, asset.

So asset (`rcap_designer.css`) can be used to override theme CSS. 