### PR TITLE
Auto-submitting slider doesn't submit for every change

### DIFF
--- a/inst/www/js/ui/controls/child/templates/slider.tpl
+++ b/inst/www/js/ui/controls/child/templates/slider.tpl
@@ -20,7 +20,6 @@ $(function() {
 		min: <%=control.getPropertyValueOrDefault('min')%>,
 		max: <%=control.getPropertyValueOrDefault('max')%>,
 		step: <%=control.getPropertyValueOrDefault('step')%>
-
     });
 	
 });

--- a/inst/www/js/ui/controls/form.js
+++ b/inst/www/js/ui/controls/form.js
@@ -177,12 +177,32 @@ define(['rcap/js/ui/controls/gridControl',
                         variableHandler.submitChange(data);
                     });
                 } else {
-                    $(this).find('[data-variablename]').change(function() {
 
-                        var value = getVarData($(this));
-
+                    var submitChange = function(control) {
+                        var value = getVarData(control);
                         if(value) {
                             variableHandler.submitChange(value);
+                        }
+                    };
+
+                    var controls = $(this).find('[data-variablename]');
+
+                    $.each(controls, function() {
+
+                        // special handling for slider:
+                        if($(this).hasClass('irs-hidden-input')) {
+                            var sliderControl = $(this);
+                            var slider = $(this).data('ionRangeSlider');
+                            slider.update({
+                                onFinish: function(data) {
+                                    submitChange(sliderControl);
+                                    console.log('onFinish!', data);
+                                }
+                            });
+                        } else {
+                            $(this).on('change', function() {
+                                submitChange($(this));
+                            });
                         }
                     });
                 }


### PR DESCRIPTION
Prior to this change, every change on a slider resulted in the submission of data; if that submission's resulting code took a while to execute, the user would be left frustrated, waiting for every iteration to execute. Really, only the 'final' change would be required.

This PR tackles this issue. The slider now hooks up the 'finish' event rather than 'change'.