### PR TITLE
Excessive whitespace trimmed from bottom of viewer pages

### DIFF
--- a/inst/www/js/ui/gridManager.js
+++ b/inst/www/js/ui/gridManager.js
@@ -498,7 +498,7 @@ define([
             }
         });
 
-        /////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
         PubSub.subscribe(pubSubTable.initSite, function(msg, site) {
 
             rcapLogger.log('gridManager: pubSubTable.initSite');
@@ -507,13 +507,22 @@ define([
             updateGridSizeMetrics(site.gridOptions);
 
             // extract the settings:
-            var settings = site.settings.extract();
+            var settings = site.settings.extract(),
+                getViewerPageHeight = function(page) {
+                  var height = 0;
+                  _.each(page.controls, function(control) {
+                    if((control.y + control.height) > height) {
+                      height = control.y + control.height;
+                    }
+                  });
+                  return height;
+                };
 
             // each page has its own grid:
             _.each(site.pages, function(page) {
                 addGrid(page, {
                     isDesignTime: site.isDesignTime,
-                    height: 48,
+                    height: site.isDesignTime ? 48 : getViewerPageHeight(page),
                     pageClass: settings.pageClass
                 });
             });


### PR DESCRIPTION
Viewer grid height was being set to 48 in all cases. Whilst this provides sufficient space for designer dashboard construction, it resulted whitespace at the bottom of pages in the viewer.

This PR calculates the height that's required by looping through each page's controls and keeping a max value for the controls' y + height.