### PR TITLE
Expose functions for managing profile variables in view mode

### DIFF
--- a/R/controlR6.R
+++ b/R/controlR6.R
@@ -11,7 +11,7 @@
 #'
 #' \code{getVariableName()} get name of associated global variable.
 #'   If there is no such variable, then \code{NULL} is returned.
-#'
+#'   
 #' \code{setVariable(new_value = NULL)} set an R variable
 #'   of a control to the specified value, coming from a
 #'   front-end update.

--- a/R/controllerR6.R
+++ b/R/controllerR6.R
@@ -105,7 +105,7 @@ controllerInitialize <- function(self, private, rcapConfig) {
 }
 
 controllerGetProfileVariables <- function(self, private) {
-  Filter(function(x) { x$getType() == 'profileVariable'}, lapply(getControls(resp), controlFactory))
+  Filter(function(x) { x$getType() == 'profileVariable'}, private$controls)
 }
 
 controllerUpdate <- function(self, private, controls) {

--- a/R/rcap.result.R
+++ b/R/rcap.result.R
@@ -58,10 +58,22 @@ haveController <- function() {
 }
 
 
-getProfileVariables <- function() {
+getUserProfileVariableValues <- function(variableName) {
   if(haveController()) {
     cnt <- get("rcapController", envir = rcapEnv)
-    return(lapply(cnt$getProfileVariables(), function(x) { x$getJson() }))
+    control <- Filter(function(x) {x$getVariableName()==variableName}, cnt$getProfileVariables())
+    if(length(control)!=1) {
+      stop(paste0("Control for profile variable '", variableName, "' not found!"));
+    }
+    control <- control[[1]]
+    has_possible_values <- !is.null(control$getControlFunctionName())
+    pos_values <- if (has_possible_values) {
+      do.call(control$getControlFunctionName(), list(), envir = rcloudEnv())
+    }
+    if(has_possible_values) {
+      return(pos_values)
+    }
+    return(list())
   } else {
     return(list())
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -33,10 +33,8 @@ rcloud.rcap.caps <- NULL
       getRTime = make_oc(function() { Sys.time() }),
       updateControls = make_oc(updateController),
       updateAllControls = make_oc(updateAllControls),
-      getProfileVariables = make_oc(getProfileVariables),
-      setUserProfileValue = make_oc(rcap.setUserProfileValue),
+      getUserProfileVariableValues = make_oc(getUserProfileVariableValues),
       getUserProfileValue = make_oc(rcap.getUserProfileValue),
-      deleteUserProfileValue = make_oc(rcap.deleteUserProfileValue),
       getRCAPVersion = make_oc(getRCAPVersion),
       getRCAPStyles = make_oc(getRCAPStyles)
    )

--- a/inst/javascript/rcloud.rcap.js
+++ b/inst/javascript/rcloud.rcap.js
@@ -55,7 +55,6 @@
                     ['getRTime'],    // not currently used
                     ['getRCAPVersion'],
                     ['getRCAPStyles'],
-                    ['getProfileVariables']
                 ], true);
 
                 RCloud.UI.advanced_menu.add({ // jshint ignore:line
@@ -103,16 +102,6 @@
                                     });
                                 };
                             });
-                            window.RCAP.getVariables = function() {
-                              return po.getProfileVariables().then(function(variables) {
-                                    return _.map(variables, function(variable) {
-                                        return {
-                                            name: variable.name,
-                                            label: variable.label
-                                        };
-                                    });
-                              });
-                            };
 
                             require(['rcap/js/designer'], function(Designer) {
                                 new Designer().initialise(extractSessionInfo(sessionInfo));
@@ -135,10 +124,8 @@
                         ['updateControls'],    // updateControls (called when a form value changes, or a form is submitted)
                         ['updateAllControls'],  // kicks off R plot rendering
                         ['getRCAPStyles'],
-                        ['getProfileVariables'],
-                        ['setUserProfileValue'],
-                        ['getUserProfileValue'],
-                        ['deleteUserProfileValue']
+                        ['getUserProfileVariableValues'],
+                        ['getUserProfileValue']
                     ], true);
 
                 window.RCAP = window.RCAP || {};
@@ -148,26 +135,27 @@
                 window.RCAP.updateAllControls = function(dataToSubmit) {
                     mini.updateAllControls(dataToSubmit).then(function() {});
                 };
-                window.RCAP.getVariables = function() {
-                    return mini.getProfileVariables().then(function(variables) {
+                window.RCAP.getUserProfileVariableValues = function(variableName) {
+                    return mini.getUserProfileVariableValues(variableName).then(function(variables) {
                         return _.map(variables, function(variable) {
                               return {
-                                  name: variable.name,
-                                  label: variable.label
+                                  value: variable
                               };
                         });
                     });
                 };
-                window.RCAP.getUserProfileValue = function(name/*, value*/) {
+                window.RCAP.getUserProfileValue = function(name) {
                     return mini.getUserProfileValue(name).then(function(variables) {
-                        return variables;
+                      if(typeof(variables)=="object") {
+                         return _.map(variables, function(variable) {
+                              return {
+                                  value: variable
+                              };
+                        });
+                      } else {
+                        return [ {value : variables} ];
+                        }
                     });
-                };
-                window.RCAP.setUserProfileValue = function(name, value) {
-                    return mini.setUserProfileValue(name, value).then(function() {});
-                };
-                window.RCAP.deleteUserProfileValue = function(name) {
-                    return mini.deleteUserProfileValue(name).then(function() {});
                 };
             }
 

--- a/inst/javascript/rcloud.rcap.js
+++ b/inst/javascript/rcloud.rcap.js
@@ -137,11 +137,15 @@
                 };
                 window.RCAP.getUserProfileVariableValues = function(variableName) {
                     return mini.getUserProfileVariableValues(variableName).then(function(variables) {
-                        return _.map(variables, function(variable) {
+                      if(typeof(variables)=="object") {
+                         return _.map(variables, function(variable) {
                               return {
                                   value: variable
                               };
                         });
+                      } else {
+                        return [ {value : variables} ];
+                        }
                     });
                 };
                 window.RCAP.getUserProfileValue = function(name) {


### PR DESCRIPTION
To perform update of the profile variable control invoke something like this to set the variable

                    var updateVarsJSON = JSON.stringify({
                        updatedVariables:[{
                            variableName: "myCountriesVariable",
                            controlId: "8b934572effe3",
                            value: ["Netherlands", "Luxemburg"]
                        }]
                    });
                    window.RCAP.updateControls(updateVarsJSON);

or to unset the variable

                    var updateVarsJSON = JSON.stringify({
                        updatedVariables:[{
                            variableName: "myCountriesVariable",
                            controlId: "8b934572effe3",
                            value: []
                        }]
                    });
                    window.RCAP.updateControls(updateVarsJSON);


to fetch available values for given profile variable invoke:
window.RCAP.getUserProfileVariableValues(variableName)

to get current user profile variable value invoke:

window.RCAP.getUserProfileValue(variableName)


Both always return an array of objects
