### PR TITLE
Menus closed when RCAP quits

### DIFF
--- a/inst/www/js/ui/menuManager.js
+++ b/inst/www/js/ui/menuManager.js
@@ -71,6 +71,7 @@ define([
             //
             PubSub.subscribe(pubSubTable.close, function() {
                 $(/*#pages li,*/ '#dataSources li, #timers li').remove();
+                $('.menu-flyout').hide();
             });
 
             //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes #247, where opened menus would stay open when RCAP was reopened.

This hides them.