### PR TITLE
Designer switches to newly created page automatically

### DIFF
--- a/inst/www/js/ui/pageTreeManager.js
+++ b/inst/www/js/ui/pageTreeManager.js
@@ -250,10 +250,11 @@ define([
                     }
 
                 });
+                */
 
                 // select the newly added page:
-                $('#pages li[data-pageid="' + msgData.pageData[0].id + '"] a').trigger('click');
-                */
+                PubSub.publish(pubSubTable.changeSelectedPageId, msgData.pageData[0].id);
+
             });
 
             PubSub.subscribe(pubSubTable.pageCountChanged, function(msg, pageCount) {


### PR DESCRIPTION
This issue was introduced when jqTree was used for the 'page tree'. The line of code to select the newly created page had been commented out, because it used an invalid selector.

This PR uses the better `changedSelectedPageId` event to update the grid.

