### PR TITLE
Duplicating pages fixed

### DIFF
--- a/inst/www/js/pages/page.js
+++ b/inst/www/js/pages/page.js
@@ -52,6 +52,7 @@ define(['rcap/js/Class'], function() {
             });
         },
         duplicate: function() {
+            /*
             // returns a duplicate page, with new (unique) page ID and control IDs:
             var dupe = $.extend(true, {}, this);
             dupe.id = generateId();
@@ -59,6 +60,17 @@ define(['rcap/js/Class'], function() {
 
             _.each(this.controls, function(c) {
                 dupe.controls.push($.extend(true, {}, c).regenerateId());
+            });
+            */
+
+            var dupe = JSON.parse(JSON.stringify(this));
+            dupe.id = generateId();
+            dupe.controls = [];
+
+            _.each(this.controls, function(c) {
+               var currentControl = JSON.parse(JSON.stringify(c));
+               currentControl.id = generateId();
+               dupe.controls.push(currentControl); 
             });
 
             return dupe;

--- a/inst/www/js/pages/page.js
+++ b/inst/www/js/pages/page.js
@@ -52,17 +52,7 @@ define(['rcap/js/Class'], function() {
             });
         },
         duplicate: function() {
-            /*
             // returns a duplicate page, with new (unique) page ID and control IDs:
-            var dupe = $.extend(true, {}, this);
-            dupe.id = generateId();
-            dupe.controls = [];
-
-            _.each(this.controls, function(c) {
-                dupe.controls.push($.extend(true, {}, c).regenerateId());
-            });
-            */
-
             var dupe = JSON.parse(JSON.stringify(this));
             dupe.id = generateId();
             dupe.controls = [];


### PR DESCRIPTION
The duplication process _intended_ to change the page and control IDs, but this was not working properly, and the duplication of IDs caused issues with non-updating plots and page menus not working. With the duplication issue apparent, it's not difficult to understand why.