### PR TITLE
Duplicate page's controls are independent

### DIFF
--- a/inst/www/js/pages/page.js
+++ b/inst/www/js/pages/page.js
@@ -34,7 +34,6 @@ define(['rcap/js/Class'], function() {
 
         },
         toJSON: function() {
-
             return {
                 'depth': this.depth,
                 'id': this.id,
@@ -44,7 +43,6 @@ define(['rcap/js/Class'], function() {
                 'controls': this.controls,
                 'pages': this.pages
             };
-
         },
         getControlByID: function(controlID) {
             return _.findWhere(this.controls, {
@@ -52,15 +50,14 @@ define(['rcap/js/Class'], function() {
             });
         },
         duplicate: function() {
-            // returns a duplicate page, with new (unique) page ID and control IDs:
-            var dupe = JSON.parse(JSON.stringify(this));
+            var dupe = $.extend(true, {}, this);
             dupe.id = generateId();
-            dupe.controls = [];
+            dupe.controls = [];     
 
             _.each(this.controls, function(c) {
-               var currentControl = JSON.parse(JSON.stringify(c));
-               currentControl.id = generateId();
-               dupe.controls.push(currentControl); 
+                var currentControl = $.extend(true, {}, c);
+                currentControl.id = generateId();
+                dupe.controls.push(currentControl);
             });
 
             return dupe;
@@ -68,7 +65,6 @@ define(['rcap/js/Class'], function() {
         canAddChild: function() {
             return this.depth <= 2;
         }
-
     });
 
     return Page;

--- a/inst/www/js/ui/gridManager.js
+++ b/inst/www/js/ui/gridManager.js
@@ -141,7 +141,7 @@ define([
             $(selector).off('change').on('change', function() {
 
                 // don't fire an event if this grid hasn't been initialised
-                if ($('.grid-stack:visible').hasClass('initialised')) {
+                if ($(selector).hasClass('initialised')) {
 
                     var hasItem = false,
                         dataItems = [];


### PR DESCRIPTION
Control IDs were not being changed in the `duplicate` method and moreover, the code that added the grid was taking the source page's details and overwriting those of the new page because of a selector issue.

This doesn't, as I thought, fix #258.