### PR TITLE
Breadcrumb control update automatically on page duplicate

### DIFF
--- a/inst/www/js/designer.js
+++ b/inst/www/js/designer.js
@@ -35,7 +35,6 @@ define([
         // hide rcap:
         $(rcapSelector).hide();
 
-        console.info('designer: PUBLISH : pubSubTable.close');
         PubSub.publish(pubSubTable.close);
     };
 

--- a/inst/www/js/pages/page.js
+++ b/inst/www/js/pages/page.js
@@ -1,6 +1,9 @@
-define(['rcap/js/Class'], function() {
+define(['controls/factories/controlFactory',
+'rcap/js/Class'], function(ControlFactory) {
 
     'use strict';
+    
+    var controlFactory = new ControlFactory();
 
     var generateId = function() {
         return 'rcap' + Math.random().toString(16).slice(2);
@@ -55,9 +58,20 @@ define(['rcap/js/Class'], function() {
             dupe.controls = [];     
 
             _.each(this.controls, function(c) {
+                /*
                 var currentControl = $.extend(true, {}, c);
                 currentControl.id = generateId();
                 dupe.controls.push(currentControl);
+                */
+
+                /*
+                var control = controlFactory.getByKey(c.type);
+                control.isOnGrid = true;
+                dupe.controls.push(control);
+                console.info('pushing control: ', control);
+                */
+
+                dupe.controls.push(controlFactory.duplicateControl(c));
             });
 
             return dupe;

--- a/inst/www/js/ui/controls/breadcrumb.js
+++ b/inst/www/js/ui/controls/breadcrumb.js
@@ -195,6 +195,8 @@ define(['rcap/js/ui/controls/gridControl',
 
                     if (me.isOnGrid) {
 
+                        console.info('pagesChanged event handler breadcrumb for: ', me.id);
+
                         // verify that the pages' order has actually changed:
                         if (_.pluck(me.pages, 'id').join() !== _.pluck(pagesInfo.pages, 'id').join()) {
                             me.pages = pagesInfo.pages;

--- a/inst/www/js/ui/controls/breadcrumb.js
+++ b/inst/www/js/ui/controls/breadcrumb.js
@@ -194,9 +194,6 @@ define(['rcap/js/ui/controls/gridControl',
                 PubSub.subscribe(pubSubTable.pagesChanged, function(msg, pagesInfo) {
 
                     if (me.isOnGrid) {
-
-                        console.info('pagesChanged event handler breadcrumb for: ', me.id);
-
                         // verify that the pages' order has actually changed:
                         if (_.pluck(me.pages, 'id').join() !== _.pluck(pagesInfo.pages, 'id').join()) {
                             me.pages = pagesInfo.pages;

--- a/inst/www/js/ui/controls/factories/controlFactory.js
+++ b/inst/www/js/ui/controls/factories/controlFactory.js
@@ -1,4 +1,4 @@
-define([
+    define([
     'controls/iframe',
     'controls/image',
     'controls/rText',
@@ -117,6 +117,35 @@ define([
 
     ControlFactory.prototype.getChildControls = function() {
         return this.childControls;
+    };
+
+    ControlFactory.prototype.duplicateControl = function(control) {
+        var dupe = this.getByKey(control.type);
+        var props = $.extend(true, {}, control);
+
+        // don't copy the id; special handling for control and style properties:
+        var propsToExclude = ['id', 'controlProperties', 'styleProperties'];
+
+        for(var p in props) {
+            if(propsToExclude.indexOf(p) === -1) {
+                dupe[p] = props[p];
+            }
+        }
+
+        var assignValues = function(propName) {
+            _.each(props[propName], function(prop) { /* jshint ignore:line */
+                var curr = _.findWhere(dupe[propName], { uid: prop.uid }); /* jshint ignore:line */
+
+                if(curr) {
+                    curr.value = prop.value;
+                }
+            });
+        };
+
+        assignValues('controlProperties');
+        assignValues('styleProperties');
+
+        return dupe;
     };
 
     ControlFactory.prototype.getByKey = function(key) {

--- a/inst/www/js/ui/dialogManager.js
+++ b/inst/www/js/ui/dialogManager.js
@@ -394,8 +394,6 @@ define([
 
             PubSub.subscribe(pubSubTable.showTimerSettingsDialog, function(msg, timer) {
 
-                console.info('dialogManager: pubSubTable.showTimerSettingsDialog');
-
                 $('#timer-form').data('timerid', timer.id);
 
                 $('#inputTimerVariable').val(timer.variable);

--- a/inst/www/js/ui/menuManager.js
+++ b/inst/www/js/ui/menuManager.js
@@ -261,14 +261,10 @@ define([
 
             // timers:
             $('body').on('click', '.menu-flyout[data-flyoutid="timers"] h4 a.add', function() {
-                console.info('menuManager: pubSubTable.addTimer');
-
                 PubSub.publish(pubSubTable.addTimer);
             });
 
             PubSub.subscribe(pubSubTable.timerAdded, function(msg, timer) {
-                console.info('menuManager: pubSubTable.timerAdded');
-
                 // add the data source to the menu:
                 var template = _.template(timerMenuItemTemplate),
                     newItemMarkup = template({
@@ -280,9 +276,6 @@ define([
             });
 
             PubSub.subscribe(pubSubTable.updateTimer, function(msg, timer) {
-
-                console.info('menuManager: pubSubTable.updateTimer');
-
                 // find the item in the menu and update:
                 var existingItem = $('#timers li[data-timerid="' + timer.id + '"]');
 
@@ -295,9 +288,6 @@ define([
             });
 
             PubSub.subscribe(pubSubTable.deleteTimerConfirm, function(msg, timerId) {
-
-                console.info('menuManager: pubSubTable.deleteTimerConfirm');
-
                 $('#timers li[data-timerid="' + timerId + '"]').remove();
             });
 

--- a/inst/www/js/ui/messageManager.js
+++ b/inst/www/js/ui/messageManager.js
@@ -12,7 +12,7 @@ define(['pubsub', 'site/pubSubTable'], function(PubSub, pubSubTable) {
 
             PubSub.subscribe(pubSubTable.showMessage, function(msg, message) {
 
-                console.info('messageManager: pubSubTable.showMessage');
+                //console.info('messageManager: pubSubTable.showMessage');
 
                 // set the text and show for a little while:
                 $(selector)

--- a/inst/www/js/ui/pageTreeManager.js
+++ b/inst/www/js/ui/pageTreeManager.js
@@ -182,8 +182,6 @@ define([
                         previousParent: event.move_info.previous_parent.id // jshint ignore:line
                       };
 
-                      console.info('page moved details: ', pageMovedDetails);
-
                       PubSub.publish(pubSubTable.pageMoved, pageMovedDetails);
                     }
                 );


### PR DESCRIPTION
`ControlFactory` `duplciateControl` method solves the issue.

The duplication code was superficially ok, but didn't hook up events that the breadcrumb need to react to.