### PR TITLE
Fix date/time format of files last modification times

### DIFF
--- a/R/controlTypes.R
+++ b/R/controlTypes.R
@@ -266,7 +266,7 @@ DataDownloadControl <- R6Class("DataDownloadControl",
                                                                    finf = file.info(path)
                                                                    if(finf$isdir) 
                                                                      return(NULL)
-                                                                   list('filename' = x, 'filesize' = finf$size, 'lastmodified' = finf$mtime)
+                                                                    list('filename' = x, 'filesize' = finf$size, 'lastmodified' = format(finf$mtime,  "%a, %d %b %Y %H:%M:%S %z"))
                                                                    }
                                                                  ))
                                         )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -59,7 +59,7 @@ rcloud.rcap.settings <- new.env()
   }
   
   # Maximum number of bytes that file can have to be downloaded
-  rcloud.rcap.settings$maxDownloadFileSize <- 50000000; 
+  rcloud.rcap.settings$maxDownloadFileSize <- 500000000; 
 }
 
 make_oc <- function(...) {

--- a/inst/www/js/ui/viewerDialogManager.js
+++ b/inst/www/js/ui/viewerDialogManager.js
@@ -280,7 +280,7 @@ define([
         function bytesToSize(bytes) {
            var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
            if (bytes === 0) {
-             return '0 Byte';
+             return '0 Bytes';
            }
            var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
            return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];


### PR DESCRIPTION
Increase file limit to 500MB
Format file sizes so units are displayed
Fix download progress spinner, so it appears when file is downloaded, not after.