### PR TITLE
Set height of sparkline graphs

### DIFF
--- a/R/dataTableControl.R
+++ b/R/dataTableControl.R
@@ -20,9 +20,9 @@ DataTableControl <- R6Class("DataTableControl",
         
         digits <- result$options$decimalPlaces
 
-        
-        result$options <- private$convertOptions(result)$options
-        result$data  <- private$convertOptions(result)$data
+        converted <- private$convertOptions(result)
+        result$options <- converted$options
+        result$data  <- converted$data
 
         # Convert the data.frame to JSON before returning
         # This gives us better control over what the client receives
@@ -52,14 +52,16 @@ DataTableControl <- R6Class("DataTableControl",
       # note: need to convert from R to javascipt counting
       # (start a 0 instead)
       possSparkColumns <- which(vapply(result$data, is.list, FUN.VALUE = TRUE))-1
-
+      
+      # Pass-through options
+      resOptions$sparklines$options <- options$sparkOptions[which(!names(options$sparkOptions) %in% c("box", "line"))]
       # set column types (histogram, line graph etc.)
       resOptions$sparklines$box <- match(options$sparkOptions$box, colNames)-1
       resOptions$sparklines$line <- match(options$sparkOptions$line, colNames)-1
       # the rest defaults to histograms
       usedColumns <- union(resOptions$columnDefs$box, resOptions$columnDefs$line)
       resOptions$sparklines$histogram <- setdiff(possSparkColumns, usedColumns)
-     
+      
       # Column css
       getClassNames <- createTableIdDf(options = options, colNames = colNames, id = private$id)
       getCellClassNames <- createCellColorId(options = options, colNames = colNames, id = private$id)

--- a/inst/www/js/utils/translators/sparklinesTranslator.js
+++ b/inst/www/js/utils/translators/sparklinesTranslator.js
@@ -11,25 +11,28 @@ define([
         // bar, line and box. 
         // The default is box.
         this.translate = function(sparklineOptions) {
-            var barFunc = function () { 
-                $('.sparkbar:not(:has(canvas))').sparkline('html', { 
+            var options = sparklineOptions.options;
+            var barFunc = function (options) { 
+                $('.sparkbar:not(:has(canvas))').sparkline('html', $.extend({ 
                     type: 'bar', 
                     barColor: 'orange', 
                     negBarColor: 'purple', 
-                    highlightColor: 'black'
-                }); 
+                    highlightColor: 'black',
+                    height: '18px'
+                }, options)); 
             };
-            var lineFunc = function () { 
-              $('.sparkline:not(:has(canvas))').sparkline('html', { 
+            var lineFunc = function (options) { 
+              $('.sparkline:not(:has(canvas))').sparkline('html', $.extend({ 
                 type: 'line', 
                 lineColor: 'black', 
                 fillColor: '#ccc', 
                 highlightLineColor: 'orange', 
-                highlightSpotColor: 'orange'
-              }); 
+                highlightSpotColor: 'orange',
+                height: '18px'
+              }, options)); 
             };
-            var boxFunc = function () {
-                $('.sparkbox:not(:has(canvas))').sparkline('html', { 
+            var boxFunc = function (options) {
+                $('.sparkbox:not(:has(canvas))').sparkline('html', $.extend({ 
                     type: 'box', 
                     lineColor: 'black', 
                     whiskerColor: 'black', 
@@ -37,8 +40,9 @@ define([
                     outlierLineColor: 'black', 
                     medianColor: 'black', 
                     boxFillColor: 'orange', 
-                    boxLineColor: 'black'
-                }); 
+                    boxLineColor: 'black',
+                    height: '18px'
+                }, options)); 
             };
 
             return {             
@@ -59,9 +63,9 @@ define([
                     targets: sparklineOptions.histogram
                 }],
                 fnDrawCallback: function () {
-                    barFunc();
-                    lineFunc();
-                    boxFunc();
+                    barFunc(options);
+                    lineFunc(options);
+                    boxFunc(options);
                 }
               };
         };


### PR DESCRIPTION
Also allow dashboard designers to override the default height (and other sparkline options) from notebook, FIX #192